### PR TITLE
Spike: Referendum-Relayer: Display veto percentage

### DIFF
--- a/packages/referendum-relayer/libs/types.d.ts
+++ b/packages/referendum-relayer/libs/types.d.ts
@@ -19,5 +19,11 @@ export interface ReferendumMessageBody {
 	proposal: ProposalInterface;
 	referendum?: ReferendumInterface;
 	vetoSum: number;
+	vetoThreshold?: number;
 	vetoPercentage?: string;
+}
+
+export interface VetoSumFields {
+	vetoThreshold: number;
+	vetoPercentage: string;
 }

--- a/packages/referendum-relayer/libs/types.d.ts
+++ b/packages/referendum-relayer/libs/types.d.ts
@@ -19,4 +19,5 @@ export interface ReferendumMessageBody {
 	proposal: ProposalInterface;
 	referendum?: ReferendumInterface;
 	vetoSum: number;
+	vetoPercentage?: string;
 }

--- a/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
+++ b/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
@@ -1,0 +1,21 @@
+import type { Api } from "@cennznet/api";
+import type { u128, Permill, EraIndex } from "@cennznet/types";
+
+export async function fetchVetoPercentage(
+	cennzApi: Api,
+	vetoSum: number
+): Promise<string> {
+	const stakingEra = (await cennzApi.query.staking.currentEra()) as EraIndex;
+
+	const totalStaked = (
+		(await cennzApi.query.staking.erasTotalStake(stakingEra.toJSON())) as u128
+	).toNumber();
+
+	const referendumThreshold = (
+		(await cennzApi.query.governance.referendumThreshold()) as Permill
+	).toNumber();
+
+	return `${(vetoSum / totalStaked).toFixed()} / ${
+		referendumThreshold / 10000
+	} %`;
+}

--- a/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
+++ b/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
@@ -5,17 +5,20 @@ export async function fetchVetoPercentage(
 	cennzApi: Api,
 	vetoSum: number
 ): Promise<string> {
-	const stakingEra = (await cennzApi.query.staking.currentEra()) as EraIndex;
+	const stakingEra = (
+		(await cennzApi.query.staking.currentEra()) as EraIndex
+	).toJSON();
 
 	const totalStaked = (
-		(await cennzApi.query.staking.erasTotalStake(stakingEra.toJSON())) as u128
+		(await cennzApi.query.staking.erasTotalStake(stakingEra)) as u128
 	).toNumber();
 
 	const referendumThreshold = (
 		(await cennzApi.query.governance.referendumThreshold()) as Permill
 	).toNumber();
 
-	return `${(vetoSum / totalStaked).toFixed()} / ${
-		referendumThreshold / 10000
-	} %`;
+	const vetoPercentage = (vetoSum / totalStaked).toFixed();
+	const thresholdPercentage = referendumThreshold / 10000;
+
+	return `${vetoPercentage} / ${thresholdPercentage} %`;
 }

--- a/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
+++ b/packages/referendum-relayer/libs/utils/fetchVetoPercentage.ts
@@ -1,6 +1,14 @@
 import type { Api } from "@cennznet/api";
 import type { u128, Permill, EraIndex } from "@cennznet/types";
 
+export async function fetchVetoThreshold(cennzApi: Api): Promise<number> {
+	const referendumThreshold = (
+		(await cennzApi.query.governance.referendumThreshold()) as Permill
+	).toNumber();
+
+	return referendumThreshold / 10000;
+}
+
 export async function fetchVetoPercentage(
 	cennzApi: Api,
 	vetoSum: number
@@ -13,12 +21,5 @@ export async function fetchVetoPercentage(
 		(await cennzApi.query.staking.erasTotalStake(stakingEra)) as u128
 	).toNumber();
 
-	const referendumThreshold = (
-		(await cennzApi.query.governance.referendumThreshold()) as Permill
-	).toNumber();
-
-	const vetoPercentage = (vetoSum / totalStaked).toFixed();
-	const thresholdPercentage = referendumThreshold / 10000;
-
-	return `${vetoPercentage} / ${thresholdPercentage} %`;
+	return (vetoSum / totalStaked).toFixed();
 }

--- a/packages/referendum-relayer/libs/utils/getDiscordMessage.ts
+++ b/packages/referendum-relayer/libs/utils/getDiscordMessage.ts
@@ -19,7 +19,7 @@ export function getDiscordMessage(
 	proposalStatus: ProposalStatus,
 	proposalDetails: ProposalDetails,
 	proposalInfo: ProposalInfo,
-	vetoSum: number | undefined
+	vetoSum: string | number | undefined
 ): DiscordMessage {
 	const referendumFields = getReferendumFields(proposalDetails, proposalInfo);
 

--- a/packages/referendum-relayer/libs/utils/getDiscordMessage.ts
+++ b/packages/referendum-relayer/libs/utils/getDiscordMessage.ts
@@ -4,6 +4,7 @@ import type {
 	ProposalStatus,
 } from "@proposal-relayer/libs/types";
 import type { DiscordMessage } from "@gov-libs/types";
+import type { VetoSumFields } from "@referendum-relayer/libs/types";
 
 import {
 	getReferendumFields,
@@ -19,7 +20,7 @@ export function getDiscordMessage(
 	proposalStatus: ProposalStatus,
 	proposalDetails: ProposalDetails,
 	proposalInfo: ProposalInfo,
-	vetoSum: string | number | undefined
+	vetoSumFields: VetoSumFields
 ): DiscordMessage {
 	const referendumFields = getReferendumFields(proposalDetails, proposalInfo);
 
@@ -35,7 +36,7 @@ export function getDiscordMessage(
 				proposalDetails.title,
 				referendumFields,
 				proposalStatus === "ReferendumDeliberation"
-					? getVetoSumField(vetoSum)
+					? getVetoSumField(vetoSumFields)
 					: undefined
 			),
 		],

--- a/packages/referendum-relayer/libs/utils/getVetoFields.ts
+++ b/packages/referendum-relayer/libs/utils/getVetoFields.ts
@@ -1,3 +1,5 @@
+import type { VetoSumFields } from "@referendum-relayer/libs/types";
+
 import { MessageActionRow, MessageButton, EmbedFieldData } from "discord.js";
 import { REFERENDUM_URL } from "@referendum-relayer/libs/constants";
 
@@ -14,11 +16,14 @@ function getVetoLink(proposalId: number): string {
 	return `${REFERENDUM_URL}/${proposalId}?stage=referendum`;
 }
 
-export function getVetoSumField(vetoSum: string | number): EmbedFieldData[] {
+export function getVetoSumField({
+	vetoThreshold,
+	vetoPercentage,
+}: VetoSumFields): EmbedFieldData[] {
 	return [
 		{
 			name: "Veto Sum",
-			value: `_**${vetoSum}**_`,
+			value: `_**${vetoPercentage} / ${vetoThreshold} %**_`,
 			inline: false,
 		},
 	];

--- a/packages/referendum-relayer/libs/utils/getVetoFields.ts
+++ b/packages/referendum-relayer/libs/utils/getVetoFields.ts
@@ -14,7 +14,7 @@ function getVetoLink(proposalId: number): string {
 	return `${REFERENDUM_URL}/${proposalId}?stage=referendum`;
 }
 
-export function getVetoSumField(vetoSum: number): EmbedFieldData[] {
+export function getVetoSumField(vetoSum: string | number): EmbedFieldData[] {
 	return [
 		{
 			name: "Veto Sum",

--- a/packages/referendum-relayer/libs/utils/handleReferendumNewMessage.ts
+++ b/packages/referendum-relayer/libs/utils/handleReferendumNewMessage.ts
@@ -15,7 +15,7 @@ const logger = getLogger("ReferendumProcessor");
 
 export async function handleReferendumNewMessage(
 	discordWebhook: InteractionWebhook,
-	{ proposalId, proposal, vetoSum }: ReferendumMessageBody,
+	{ proposalId, proposal, vetoSum, vetoThreshold }: ReferendumMessageBody,
 	queue: AMQPQueue,
 	message: AMQPMessage,
 	abortSignal: AbortSignal
@@ -53,7 +53,7 @@ export async function handleReferendumNewMessage(
 			status as ProposalStatus,
 			proposalDetails,
 			proposalInfo,
-			vetoSum
+			{ vetoPercentage: "0", vetoThreshold }
 		);
 
 		const { id: discordMessageId } = await discordWebhook.send(discordMessage);

--- a/packages/referendum-relayer/libs/utils/handleReferendumUpdateMessage.ts
+++ b/packages/referendum-relayer/libs/utils/handleReferendumUpdateMessage.ts
@@ -15,7 +15,13 @@ const logger = getLogger("ReferendumProcessor");
 
 export async function handleReferendumUpdateMessage(
 	discordWebhook: InteractionWebhook,
-	{ proposalId, proposal, referendum, vetoSum }: ReferendumMessageBody,
+	{
+		proposalId,
+		proposal,
+		referendum,
+		vetoSum,
+		vetoPercentage,
+	}: ReferendumMessageBody,
 	queue: AMQPQueue,
 	message: AMQPMessage,
 	abortSignal: AbortSignal
@@ -53,7 +59,7 @@ export async function handleReferendumUpdateMessage(
 			status as ProposalStatus,
 			proposalDetails,
 			proposalInfo,
-			status === "ReferendumDeliberation" ? vetoSum : undefined
+			status === "ReferendumDeliberation" ? vetoPercentage : undefined
 		);
 
 		await discordWebhook.editMessage(

--- a/packages/referendum-relayer/libs/utils/handleReferendumUpdateMessage.ts
+++ b/packages/referendum-relayer/libs/utils/handleReferendumUpdateMessage.ts
@@ -21,6 +21,7 @@ export async function handleReferendumUpdateMessage(
 		referendum,
 		vetoSum,
 		vetoPercentage,
+		vetoThreshold,
 	}: ReferendumMessageBody,
 	queue: AMQPQueue,
 	message: AMQPMessage,
@@ -59,7 +60,7 @@ export async function handleReferendumUpdateMessage(
 			status as ProposalStatus,
 			proposalDetails,
 			proposalInfo,
-			status === "ReferendumDeliberation" ? vetoPercentage : undefined
+			{ vetoPercentage, vetoThreshold }
 		);
 
 		await discordWebhook.editMessage(

--- a/packages/referendum-relayer/libs/utils/monitorVetoSum.ts
+++ b/packages/referendum-relayer/libs/utils/monitorVetoSum.ts
@@ -5,6 +5,7 @@ import type { ReferendumVoteCount, StorageKey } from "@cennznet/types";
 import { getLogger } from "@gov-libs/utils/getLogger";
 import { Referendum } from "@referendum-relayer/libs/models";
 import { Proposal } from "@proposal-relayer/libs/models";
+import { fetchVetoPercentage } from "./fetchVetoPercentage";
 
 const logger = getLogger("ReferendumListener");
 
@@ -44,8 +45,16 @@ export async function monitorVetoSum(
 						"Referendum #%d: Update found, sent to queue...",
 						proposalId
 					);
+
+					const vetoPercentage = await fetchVetoPercentage(cennzApi, vetoSum);
 					queue.publish(
-						JSON.stringify({ proposalId, proposal, referendum, vetoSum }),
+						JSON.stringify({
+							proposalId,
+							proposal,
+							referendum,
+							vetoSum,
+							vetoPercentage,
+						}),
 						{
 							type: "update",
 						}


### PR DESCRIPTION
## Why

 - Fetch & calculate veto percentage and display on Discord
 - Closes #9

## What is changing

 - add `fetchVetoPercentage` util
 - if message type is `new`, fetch and display veto threshold
 - if message type is `update`, fetch and display veto percentage

## Screenshot
<img width="442" alt="Screen Shot 2022-06-29 at 1 32 15 PM" src="https://user-images.githubusercontent.com/52016903/176332482-b840a0ba-5ab8-4146-b5ce-a1c833f6d476.png">
